### PR TITLE
fix: fix unbinding of listeners on remove

### DIFF
--- a/src/leaflet.groupedlayercontrol.js
+++ b/src/leaflet.groupedlayercontrol.js
@@ -46,8 +46,8 @@ L.Control.GroupedLayers = L.Control.extend({
 
   onRemove: function (map) {
     map
-        .off('layeradd', this._onLayerChange)
-        .off('layerremove', this._onLayerChange);
+        .off('layeradd', this._onLayerChange, this)
+        .off('layerremove', this._onLayerChange, this);
   },
 
   addBaseLayer: function (layer, name) {


### PR DESCRIPTION
This fixes an issue where after removing the control from the map and adding in a new one you could not change layers.
It would think the map is null due to old listeners being around.

[You can see the same thing is done in the onRemove of the normal layers control.](https://github.com/Leaflet/Leaflet/blob/27263b7afaf79f85fb0b056d96388f9f8eed87c2/src/control/Control.Layers.js#L120)